### PR TITLE
Building cc binary with rust dependencies

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -51,6 +51,7 @@ cc_library(
     name = "core-lib",
     srcs = ["src/cxx.cc"],
     hdrs = ["include/cxx.h"],
+    visibility = ["//visibility:public"],
 )
 
 rust_proc_macro(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,5 +1,16 @@
 module(name = "cxx.rs")
 
+# Hedron's Compile Commands Extractor for Bazel
+# https://github.com/hedronvision/bazel-compile-commands-extractor
+bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
+git_override(
+    module_name = "hedron_compile_commands",
+    remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
+    commit = "0e990032f3c5a866e72615cf67e5ce22186dcb97",
+    # Replace the commit hash (above) with the latest (https://github.com/hedronvision/bazel-compile-commands-extractor/commits/main).
+    # Even better, set up Renovate and let it do the work for you (see "Suggestion: Updates" in the README).
+)
+
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_cc", version = "0.0.17")
 bazel_dep(name = "rules_rust", version = "0.57.1")

--- a/demo/BUILD.bazel
+++ b/demo/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
-load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_binary")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_static_library")
 load("//tools/bazel:rust_cxx_bridge.bzl", "rust_cxx_bridge")
 
 rust_binary(
@@ -9,6 +9,29 @@ rust_binary(
     deps = [
         ":blobstore-sys",
         ":bridge",
+        "//:cxx",
+    ],
+)
+
+rust_static_library(
+    name = "demolib",
+    srcs = ["src/main.rs"],
+    edition = "2021",
+    deps = [
+        ":blobstore-sys",
+        ":bridge",
+        "//:cxx",
+    ],
+)
+
+cc_binary(
+    name = "democc",
+    srcs = ["src/main.cc"],
+    copts = ["-std=c++17"],
+    deps = [
+        ":blobstore-sys",
+        ":bridge",
+        ":demolib",
         "//:cxx",
     ],
 )

--- a/demo/src/main.cc
+++ b/demo/src/main.cc
@@ -1,0 +1,24 @@
+#include <iostream>
+
+#include "demo/include/blobstore.h"
+#include "demo/src/main.rs.h"
+
+int main() {
+  auto client = org::blobstore::new_blobstore_client();
+
+  // Upload a blob.
+  std::string str("hello world");
+  std::vector<uint8_t> vec(str.begin(), str.end());
+  ::rust::Vec<uint8_t> rvec{};
+  std::copy(vec.begin(), vec.end(), std::back_inserter(rvec));
+  ::rust::Box<org::blobstore::MultiBuf> buf =
+      org::blobstore::create_multibuf(rvec);
+  auto blobid = client->put(*buf);
+
+  // Add a tag.
+  client->tag(blobid, "rust");
+
+  // Read back the tags.
+  auto metadata = client->metadata(blobid);
+  std::cout << "tags = " << metadata.tags[0] << std::endl;
+}

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -1,7 +1,7 @@
 #[cxx::bridge(namespace = "org::blobstore")]
 mod ffi {
     // Shared structs with fields visible to both languages.
-    struct BlobMetadata {
+    pub struct BlobMetadata {
         size: usize,
         tags: Vec<String>,
     }
@@ -10,6 +10,7 @@ mod ffi {
     extern "Rust" {
         type MultiBuf;
 
+        fn create_multibuf(chunk: Vec<u8>) -> Box<MultiBuf>;
         fn next_chunk(buf: &mut MultiBuf) -> &[u8];
     }
 
@@ -19,10 +20,10 @@ mod ffi {
 
         type BlobstoreClient;
 
-        fn new_blobstore_client() -> UniquePtr<BlobstoreClient>;
-        fn put(&self, parts: &mut MultiBuf) -> u64;
-        fn tag(&self, blobid: u64, tag: &str);
-        fn metadata(&self, blobid: u64) -> BlobMetadata;
+        pub fn new_blobstore_client() -> UniquePtr<BlobstoreClient>;
+        pub fn put(&self, parts: &mut MultiBuf) -> u64;
+        pub fn tag(&self, blobid: u64, tag: &str);
+        pub fn metadata(&self, blobid: u64) -> BlobMetadata;
     }
 }
 
@@ -32,8 +33,14 @@ mod ffi {
 // over some more complex Rust data structure like a rope, or maybe loading
 // chunks lazily from somewhere.
 pub struct MultiBuf {
-    chunks: Vec<Vec<u8>>,
-    pos: usize,
+    pub chunks: Vec<Vec<u8>>,
+    pub pos: usize,
+}
+pub fn create_multibuf(chunk: Vec<u8>) -> Box<MultiBuf> {
+    Box::new(MultiBuf {
+        chunks: vec![chunk],
+        pos: 0,
+    })
 }
 pub fn next_chunk(buf: &mut MultiBuf) -> &[u8] {
     let next = buf.chunks.get(buf.pos);


### PR DESCRIPTION
This is failing with error:
```
ERROR: /home/maxim/src/rust/cxx/demo/BUILD.bazel:16:10: Linking demo/democc failed: (Exit 1): linux-sandbox failed: error executing CppLink command 
  (cd /home/maxim/.cache/bazel/_bazel_maxim/9a0a14cdd72bc9df5400d22d4d657a3e/sandbox/linux-sandbox/50/execroot/_main && \
  exec env - \
    PATH=/home/maxim/.cache/bazelisk/downloads/sha256/40f243b118f46d1c88842315e78ec5f9f6390980d67a90f7b64098613e60d65b/bin:/opt/intel/oneapi/vtune/2023.2.0/bin64:/opt/intel/oneapi/vtune/latest/bin64/:/usr/local/cuda/bin:/home/maxim/.local/bin:/opt/intel/oneapi/vtune/2023.2.0/bin64:/opt/intel/oneapi/vtune/latest/bin64/:/usr/local/cuda/bin:/home/maxim/.cargo/bin:/home/maxim/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/snap/bin:/usr/local/go/bin:/home/maxim/go/bin:/usr/local/go/bin:/home/maxim/go/bin \
    PWD=/proc/self/cwd \
    TMPDIR=/tmp \
    ZERO_AR_DATE=1 \
  /home/maxim/.cache/bazel/_bazel_maxim/install/3fd603d608c2d3b856ea3d982b11227c/linux-sandbox -t 15 -w /dev/shm -w /home/maxim/.cache/bazel/_bazel_maxim/9a0a14cdd72bc9df5400d22d4d657a3e/sandbox/linux-sandbox/50/execroot/_main -w /tmp -M /home/maxim/.cache/bazel/_bazel_maxim/9a0a14cdd72bc9df5400d22d4d657a3e/sandbox/linux-sandbox/50/_hermetic_tmp -m /tmp -S /home/maxim/.cache/bazel/_bazel_maxim/9a0a14cdd72bc9df5400d22d4d657a3e/sandbox/linux-sandbox/50/stats.out -D /home/maxim/.cache/bazel/_bazel_maxim/9a0a14cdd72bc9df5400d22d4d657a3e/sandbox/linux-sandbox/50/debug.out -- /usr/bin/gcc @bazel-out/k8-fastbuild/bin/demo/democc-0.params)
bazel-out/k8-fastbuild/bin/demo/_objs/bridge/main.rs.pic.o:main.rs.cc:function org::blobstore::MultiBuf::layout::size(): error: undefined reference to 'org$blobstore$cxxbridge1$MultiBuf$operator$sizeof'
bazel-out/k8-fastbuild/bin/demo/_objs/bridge/main.rs.pic.o:main.rs.cc:function org::blobstore::MultiBuf::layout::align(): error: undefined reference to 'org$blobstore$cxxbridge1$MultiBuf$operator$alignof'
bazel-out/k8-fastbuild/bin/demo/_objs/bridge/main.rs.pic.o:main.rs.cc:function org::blobstore::create_multibuf(rust::cxxbridge1::Vec<unsigned char>): error: undefined reference to 'org$blobstore$cxxbridge1$create_multibuf'
bazel-out/k8-fastbuild/bin/demo/_objs/bridge/main.rs.pic.o:main.rs.cc:function org::blobstore::next_chunk(org::blobstore::MultiBuf&): error: undefined reference to 'org$blobstore$cxxbridge1$next_chunk'
bazel-out/k8-fastbuild/bin/demo/_objs/bridge/main.rs.pic.o:main.rs.cc:function rust::cxxbridge1::Box<org::blobstore::MultiBuf>::allocation::alloc(): error: undefined reference to 'cxxbridge1$box$org$blobstore$MultiBuf$alloc'
bazel-out/k8-fastbuild/bin/demo/_objs/bridge/main.rs.pic.o:main.rs.cc:function rust::cxxbridge1::Box<org::blobstore::MultiBuf>::allocation::dealloc(org::blobstore::MultiBuf*): error: undefined reference to 'cxxbridge1$box$org$blobstore$MultiBuf$dealloc'
bazel-out/k8-fastbuild/bin/demo/_objs/bridge/main.rs.pic.o:main.rs.cc:function rust::cxxbridge1::Box<org::blobstore::MultiBuf>::drop(): error: undefined reference to 'cxxbridge1$box$org$blobstore$MultiBuf$drop'
bazel-out/k8-fastbuild/bin/_objs/core-lib/cxx.pic.o:cxx.cc:function rust::cxxbridge1::String::String(): error: undefined reference to 'cxxbridge1$string$new'
bazel-out/k8-fastbuild/bin/_objs/core-lib/cxx.pic.o:cxx.cc:function rust::cxxbridge1::String::String(rust::cxxbridge1::String const&): error: undefined reference to 'cxxbridge1$string$clone'
bazel-out/k8-fastbuild/bin/_objs/core-lib/cxx.pic.o:cxx.cc:function rust::cxxbridge1::String::String(rust::cxxbridge1::String&&): error: undefined reference to 'cxxbridge1$string$new'
bazel-out/k8-fastbuild/bin/_objs/core-lib/cxx.pic.o:cxx.cc:function rust::cxxbridge1::String::~String(): error: undefined reference to 'cxxbridge1$string$drop'
bazel-out/k8-fastbuild/bin/_objs/core-lib/cxx.pic.o:cxx.cc:function rust::cxxbridge1::initString(rust::cxxbridge1::String*, char const*, unsigned long): error: undefined reference to 'cxxbridge1$string$from_utf8'
bazel-out/k8-fastbuild/bin/_objs/core-lib/cxx.pic.o:cxx.cc:function rust::cxxbridge1::initString(rust::cxxbridge1::String*, char16_t const*, unsigned long): error: undefined reference to 'cxxbridge1$string$from_utf16'
bazel-out/k8-fastbuild/bin/_objs/core-lib/cxx.pic.o:cxx.cc:function rust::cxxbridge1::String::String(rust::cxxbridge1::String::lossy_t, char const*, unsigned long): error: undefined reference to 'cxxbridge1$string$from_utf8_lossy'
bazel-out/k8-fastbuild/bin/_objs/core-lib/cxx.pic.o:cxx.cc:function rust::cxxbridge1::String::String(rust::cxxbridge1::String::lossy_t, char16_t const*, unsigned long): error: undefined reference to 'cxxbridge1$string$from_utf16_lossy'
bazel-out/k8-fastbuild/bin/_objs/core-lib/cxx.pic.o:cxx.cc:function rust::cxxbridge1::String::operator=(rust::cxxbridge1::String const&) &: error: undefined reference to 'cxxbridge1$string$drop'
bazel-out/k8-fastbuild/bin/_objs/core-lib/cxx.pic.o:cxx.cc:function rust::cxxbridge1::String::operator=(rust::cxxbridge1::String const&) &: error: undefined reference to 'cxxbridge1$string$clone'
...
```

contents of democc-0.params:
```
❯ cat bazel-out/k8-fastbuild/bin/demo/democc-0.params
-o
bazel-out/k8-fastbuild/bin/demo/democc
-Wl,-S
-fuse-ld=gold
-B/usr/bin
-Wl,-no-as-needed
-Wl,-z,relro,-z,now
-pass-exit-codes
bazel-out/k8-fastbuild/bin/demo/_objs/democc/main.pic.o
-Wl,--start-lib
bazel-out/k8-fastbuild/bin/demo/_objs/blobstore-sys/blobstore.pic.o
-Wl,--end-lib
-Wl,--start-lib
bazel-out/k8-fastbuild/bin/demo/_objs/bridge/main.rs.pic.o
-Wl,--end-lib
bazel-out/k8-fastbuild/bin/libcxx-3687376307.a
-Wl,--start-lib
bazel-out/k8-fastbuild/bin/_objs/core-lib/cxx.pic.o
-Wl,--end-lib
bazel-out/k8-fastbuild/bin/external/+crate_repositories+vendor__foldhash-0.1.4/libfoldhash-1264529756.a
bazel-out/k8-fastbuild/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libtest-3f2fb5628a902976.a
bazel-out/k8-fastbuild/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/librustc_std_workspace_alloc-5742b2ff1aee27a6.a
bazel-out/k8-fastbuild/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/librustc_std_workspace_core-0ca9d0e07c79bf1c.a
bazel-out/k8-fastbuild/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/librustc_std_workspace_std-cc5e90924cebe413.a
bazel-out/k8-fastbuild/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd-057643b1ee86c6e4.a
bazel-out/k8-fastbuild/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd_detect-766a7f754c8a7b1e.a
bazel-out/k8-fastbuild/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libaddr2line-bea85df8985bb2f0.a
bazel-out/k8-fastbuild/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcfg_if-a6ffb752c82ede63.a
bazel-out/k8-fastbuild/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libgetopts-faba618726e33e66.a
bazel-out/k8-fastbuild/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libgimli-042a1cb2143833ef.a
bazel-out/k8-fastbuild/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libhashbrown-9b015ab0e459320f.a
bazel-out/k8-fastbuild/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/liblibc-c896c1f3ebd992a5.a
bazel-out/k8-fastbuild/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libminiz_oxide-d03b432324732a0e.a
bazel-out/k8-fastbuild/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libobject-8f13995dfe88b143.a
bazel-out/k8-fastbuild/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libpanic_unwind-8e63f34add4b5f76.a
bazel-out/k8-fastbuild/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libproc_macro-53bdffff3ca9feef.a
bazel-out/k8-fastbuild/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libprofiler_builtins-f63320f165eccbac.a
bazel-out/k8-fastbuild/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/librustc_demangle-092847c11df9843e.a
bazel-out/k8-fastbuild/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libsysroot-bee2d06ba2b291cb.a
bazel-out/k8-fastbuild/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libunicode_width-cb7e1a26da719554.a
bazel-out/k8-fastbuild/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libunwind-b3cefab73e1d8804.a
bazel-out/k8-fastbuild/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libmemchr-45742ba23c5ac84b.a
bazel-out/k8-fastbuild/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libadler-7edbe936f6124018.a
bazel-out/k8-fastbuild/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcore-1e6496089ac34c68.a
bazel-out/k8-fastbuild/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcompiler_builtins-3d4809363f767eb8.a
bazel-out/k8-fastbuild/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/liballoc-915fd1ebf7e3c376.a
-Wl,--start-lib
bazel-out/k8-fastbuild/bin/external/rules_rust+/ffi/cc/allocator_library/_objs/allocator_library/allocator_library.pic.o
-Wl,--end-lib
-ldl
-lpthread
-Wl,--push-state,-as-needed
-lstdc++
-Wl,--pop-state
-Wl,--push-state,-as-needed
-lm
-Wl,--pop-state
```